### PR TITLE
added intercept call to terminate existing scroll events

### DIFF
--- a/extensions/anchorscroll.overthrow.js
+++ b/extensions/anchorscroll.overthrow.js
@@ -4,6 +4,7 @@
 	if( w.overthrow && w.addEventListener ){
 		
 		function scrollToElem ( elem ){
+		  overthrow.intercept();
 			var throwParent = overthrow.closest( elem );
 			if( throwParent ){
 				overthrow.toss(


### PR DESCRIPTION
If a user clicks during an existing scroll event the system gets jammed up. This simple workaround merely adds a call to overthrow.intercept to terminate any existing scroll events.
