### PR TITLE
Properly resetting arrays

### DIFF
--- a/overthrow.js
+++ b/overthrow.js
@@ -197,12 +197,12 @@
 				
 				// For a new gesture, or change in direction, reset the values from last scroll
 				resetVertTracking = function(){
-					lastTops = [];
+					lastTops.length = 0;
 					lastDown = null;
 				},
 				
 				resetHorTracking = function(){
-					lastLefts = [];
+					lastLefts.length = 0;
 					lastRight = null;
 				},
 				


### PR DESCRIPTION
Instead of initiating new arrays, it's better to set the length of the existing ones to 0 according to many JS geeks out there: http://davidwalsh.name/empty-array, http://css-tricks.com/snippets/javascript/empty-an-array/
