### PR TITLE
Updated UA strings to match some newer browsers

### DIFF
--- a/overthrow.js
+++ b/overthrow.js
@@ -31,6 +31,9 @@
 					/* Android 3+ with webkit gte 534
 					~: Mozilla/5.0 (Linux; U; Android 3.0; en-us; Xoom Build/HRI39) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13 */
 					ua.match( /Android ([0-9]+)/ ) && RegExp.$1 >= 3 && wkLte534 ||
+					/* Windows Phone 
+					~: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920) */
+					ua.match(/IEMobile\/(\d\d).\d+/) && RegExp.$1 >= 10 ||
 					/* Blackberry 7+ with webkit gte 534
 					~: Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en-US) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.0.0 Mobile Safari/534.11+ */
 					ua.match( / Version\/([0-9]+)/ ) && RegExp.$1 >= 0 && w.blackberry && wkLte534 ||
@@ -38,8 +41,8 @@
 					~: Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/0.0.1 Safari/534.8+ */   
 					ua.indexOf( /PlayBook/ ) > -1 && RegExp.$1 >= 0 && wkLte534 ||
 					/* Firefox Mobile (Fennec) 4 and up
-					~: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:2.1.1) Gecko/ Firefox/4.0.2pre Fennec/4.0. */
-					ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 >= 4 ||
+					~: Mozilla/5.0 (Mobile; rv:15.0) Gecko/15.0 Firefox/15.0 */
+					ua.match(/Firefox\/([0-9]+)/) && RegExp.$1 >= 4 ||
 					/* WebOS 3 and up (TouchPad too)
 					~: Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.48 Safari/534.6 TouchPad/1.0 */
 					ua.match( /wOSBrowser\/([0-9]+)/ ) && RegExp.$1 >= 233 && wkLte534 ||


### PR DESCRIPTION
Added Windows Phone (IE Mobile v>10) support, and loosened the Firefox Phone/Firefox for Android check since Fennec is no longer in the UA string.
