### PR TITLE
Add Grunt plugins: jshint and watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,19 @@ module.exports = function(grunt) {
         dest: 'dist/<%= pkg.name %>.sidescroller.min.js'
       }
     },
+    jshint: {
+      options: {
+        curly: true,
+        latedef: true,
+        trailing: true,
+        unused: 'vars'
+      },
+      all: ['examples/**/*.js', 'extensions/**/*.js', 'src/**/*.js', 'test/*.js', 'Gruntfile.js', 'package.json']
+    },
+    watch: {
+      files: ['**/*'],
+      tasks: ['jshint'],
+    }
   });
 
   // These plugins provide necessary tasks.
@@ -46,6 +59,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
   // Default task.
   grunt.registerTask('default', ['concat', 'uglify']);

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   "devDependencies": {
     "grunt": "0.4.0",
     "grunt-contrib-concat": "0.1.3",
-    "grunt-contrib-watch": "0.1.3",
+    "grunt-contrib-watch": "~0.5.1",
     "grunt-contrib-uglify": "~0.2.2",
-    "grunt-contrib-qunit": "~0.2.2"
+    "grunt-contrib-qunit": "~0.2.2",
+    "grunt-contrib-jshint": "~0.6.2"
   }
 }


### PR DESCRIPTION
Added jshint and watch as Grunt plugins. Watch is configured to run jshint automatically as soon as it detects a file change.
