### PR TITLE
Don't rely on window.overthrow to exist by the time overflow.set() is invoked

### DIFF
--- a/src/overthrow-detect.js
+++ b/src/overthrow-detect.js
@@ -53,41 +53,41 @@
 			})();
 
 	// Expose overthrow API
-	w.overthrow = {};
+	var overthrow = w.overthrow = {};
 
-	w.overthrow.enabledClassName = enabledClassName;
+	overthrow.enabledClassName = enabledClassName;
 
-	w.overthrow.addClass = function(){
-		if( docElem.className.indexOf( w.overthrow.enabledClassName ) === -1 ){
-			docElem.className += " " + w.overthrow.enabledClassName;
+	overthrow.addClass = function(){
+		if( docElem.className.indexOf( overthrow.enabledClassName ) === -1 ){
+			docElem.className += " " + overthrow.enabledClassName;
 		}
 	};
 
-	w.overthrow.removeClass = function(){
-		docElem.className = docElem.className.replace( w.overthrow.enabledClassName, "" );
+	overthrow.removeClass = function(){
+		docElem.className = docElem.className.replace( overthrow.enabledClassName, "" );
 	};
 
 	// Enable and potentially polyfill overflow
-	w.overthrow.set = function(){
+	overthrow.set = function(){
 			
 		// If nativeOverflow or at least the element canBeFilledWithPoly, add a class to cue CSS that assumes overflow scrolling will work (setting height on elements and such)
 		if( nativeOverflow ){
-			w.overthrow.addClass();
+			overthrow.addClass();
 		}
 
 	};
 
 	// expose polyfillable 
-	w.overthrow.canBeFilledWithPoly = canBeFilledWithPoly;
+	overthrow.canBeFilledWithPoly = canBeFilledWithPoly;
 
 	// Destroy everything later. If you want to.
-	w.overthrow.forget = function(){
+	overthrow.forget = function(){
 
-		w.overthrow.removeClass();
+		overthrow.removeClass();
 		
 	};
 		
 	// Expose overthrow API
-	w.overthrow.support = nativeOverflow ? "native" : "none";
+	overthrow.support = nativeOverflow ? "native" : "none";
 		
 })( this );

--- a/src/overthrow-polyfill.js
+++ b/src/overthrow-polyfill.js
@@ -32,9 +32,9 @@
 		// If nativeOverflow or it doesn't look like the browser canBeFilledWithPoly, our job is done here. Exit viewport left.
 		if( enabled || nativeOverflow || !canBeFilledWithPoly ){
 			return;
-		}
+		};
 
-		w.overthrow.addClass();
+		o.addClass();
 
 		enabled = true;
 


### PR DESCRIPTION
While `overthrow-polyfill` takes `overthrow` object from window and stores it in a variable at load time, later both polyfill and `overthrow-detect` try to access Overthrow indirectly on the window object. Usually it is fine, as long as you have control over the page where Overthrow is used.

In our case, however, Overthrow was a dependency of another JavaScript plugin, that tries to make a few assumptions as possible about the page including it. That means it does not assume another Overthrow instance won't be created by something else on the page, or that `overthrow` global won't be overwritten by something entirely unrelated. So here's a patch for Overthrow not to look for itself on the window object after load.

The assumption that `overthrow-polyfill` is loaded immediately after `overthrow-detect` stays.
