### PR TITLE
Update overthrow-polyfill.js

### DIFF
--- a/src/overthrow-polyfill.js
+++ b/src/overthrow-polyfill.js
@@ -20,7 +20,7 @@
 
 	// find closest overthrow (elem or a parent)
 	o.closest = function( target, ascend ){
-		return !ascend && target.className && target.className.indexOf( scrollIndicatorClassName ) > -1 && target || o.closest( target.parentNode );
+		return !ascend && target && (target.className && target.className.indexOf(scrollIndicatorClassName) > -1) || o.closest(target.parentNode);
 	};
 		
 	// polyfill overflow


### PR DESCRIPTION
We were seeing a random error in newrelic logs about target not being available.  Changed this to check for target before trying to accessing a property of it.
