### PR TITLE
make indexOf() checks consistent

### DIFF
--- a/src/overthrow-detect.js
+++ b/src/overthrow-detect.js
@@ -38,7 +38,7 @@
 					ua.match( / Version\/([0-9]+)/ ) && RegExp.$1 >= 0 && w.blackberry && wkLte534 ||
 					/* Blackberry Playbook with webkit gte 534
 					~: Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.8+ (KHTML, like Gecko) Version/0.0.1 Safari/534.8+ */   
-					ua.indexOf( "PlayBook" ) > -1 && wkLte534 && !ua.indexOf( "Android 2" ) === -1 ||
+					ua.indexOf( "PlayBook" ) > -1 && wkLte534 && ua.indexOf( "Android 2" ) > -1 ||
 					/* Firefox Mobile (Fennec) 4 and up
 					~: Mozilla/5.0 (Mobile; rv:15.0) Gecko/15.0 Firefox/15.0 */
 					ua.match(/Firefox\/([0-9]+)/) && RegExp.$1 >= 4 ||


### PR DESCRIPTION
The use of `ua.indexOf( "PlayBook" ) > -1` and `!ua.indexOf( "Android 2" ) === -1` on the same line made me go: "Wait, aren't those both checking for the presence of a string in `ua`? Or are they subtly different and I'm just missing something? I'm totally confused."

Since they are, in fact, both checking that the return value is 0 or above, I changed the second one to the format of the first one. I mean, I guess it doesn't really matter, but it should probably be one or the other and not both...

Although I also don't see "Android 2" in the UA string in the comment above. So now I'm puzzled again. Bug?
