### PR TITLE
bug: account for target with Object className

### DIFF
--- a/src/overthrow-polyfill.js
+++ b/src/overthrow-polyfill.js
@@ -20,7 +20,7 @@
 
 	// find closest overthrow (elem or a parent)
 	o.closest = function( target, ascend ){
-		return !ascend && target.className && target.className.indexOf( scrollIndicatorClassName ) > -1 && target || o.closest( target.parentNode );
+		return !ascend && target.className && typeof target.className === 'string' && target.className.indexOf( scrollIndicatorClassName ) > -1 && target || o.closest( target.parentNode );
 	};
 		
 	// polyfill overflow


### PR DESCRIPTION
- Fix for o.closest target as an svg
- Fixes #78 

Failing test already exists in the current implementation of Overthrow
